### PR TITLE
ensure that user list is retrieved from user info

### DIFF
--- a/ispyb_lib.py
+++ b/ispyb_lib.py
@@ -166,7 +166,7 @@ def create_people(proposal_id, current_usernames, users_info, dry_run=True):
         is_pi = False
         if not person_id:  # the Person doesn't exist in ISPyB yet
             # extract first and last names from proposal info
-            for user_info in users_info:
+            for user_info in users_info["users"]:
                 if username == user_info["username"]:
                     first_name = user_info["first_name"]
                     last_name = user_info["last_name"]


### PR DESCRIPTION
I found this problem as I was testing from the command line - just needed to get the list of users from the dictionary.

I intend to push v0.0.7 up to include this fix (after merging) - please let me know if there are any objections. (I am trying to get the nsls2api_ispyb_populator role fixed so that it uses v0.0.7 as well.)